### PR TITLE
Modernize code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 #
 #   Carl Lei <xecycle@gmail.com>
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
 
 project(BambooShoot3)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,10 +27,9 @@ set(PROJECT_VERSION ${BambooShoot3_VERSION})
 set(BambooShoot3_VERSION_MAJOR ${BambooShoot3_VERSION})
 set(PROJECT_VERSION_MAJOR ${BambooShoot3_VERSION})
 
-set(BambooShoot3_BUILD_CXXSTD_FLAGS "-std=c++14"
-  CACHE STRING "Flag for specifying language standard")
+set(CMAKE_CXX_STANDARD 20)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${BambooShoot3_BUILD_CXXSTD_FLAGS} -Wpedantic -Wall -Wextra -Wconversion -Werror")
+add_compile_options(-Wpedantic -Wall -Wextra -Wconversion -Werror)
 
 # external deps
 set(DEPS_LZO_PATH ${PROJECT_SOURCE_DIR}/deps/lzo)

--- a/include/bs3/pbss/impl/pbss-serialize-iterable-fwd.hh
+++ b/include/bs3/pbss/impl/pbss-serialize-iterable-fwd.hh
@@ -37,17 +37,17 @@ using std::end;
 
 // define size() for arrays
 template <class T, std::size_t N>
-constexpr std::size_t size(const T(&array)[N]);
+constexpr std::size_t pbss_size(const T(&array)[N]);
 
 // for class with member .size()
 template <class T>
-constexpr auto size(const T& coll) -> decltype(coll.size());
+constexpr auto pbss_size(const T& coll) -> decltype(coll.size());
 
 // and the implementation allows ADL override
 
 template <class T>
 auto check_sized_iterable() -> decltype(
-  size(std::declval<T&>()),
+  pbss_size(std::declval<T&>()),
   begin(std::declval<T&>()) != end(std::declval<T&>()),
   ++std::declval<decltype(begin(std::declval<T&>()))&>(),
   *begin(std::declval<T&>()),

--- a/include/bs3/pbss/impl/pbss-var-uint.hh
+++ b/include/bs3/pbss/impl/pbss-var-uint.hh
@@ -25,6 +25,7 @@
 #define BS3_PBSS_VAR_UINT_HH
 
 #include <type_traits>
+#include <cstdint>
 
 #include <bs3/utils/functional.hh>
 

--- a/include/bs3/utils/tuple-util.hh
+++ b/include/bs3/utils/tuple-util.hh
@@ -26,6 +26,7 @@
 
 // utilities specific to std::tuple
 
+#include <cstddef>
 #include <tuple>
 #include <utility>
 

--- a/src/pbsf/CMakeLists.txt
+++ b/src/pbsf/CMakeLists.txt
@@ -18,8 +18,8 @@
 #
 #   Carl Lei <xecycle@gmail.com>
 
-include_directories(${DEPS_LZO_PATH})
-include_directories(${DEPS_ZSTD_PATH}/lib ${DEPS_ZSTD_PATH}/lib/common)
+include_directories(SYSTEM ${DEPS_LZO_PATH})
+include_directories(SYSTEM ${DEPS_ZSTD_PATH}/lib ${DEPS_ZSTD_PATH}/lib/common)
 
 aux_source_directory(${DEPS_ZSTD_PATH}/lib/common ZSTD_COMMON_FILES)
 aux_source_directory(${DEPS_ZSTD_PATH}/lib/compress ZSTD_COMPRESS_FILES)
@@ -28,6 +28,7 @@ aux_source_directory(${DEPS_ZSTD_PATH}/lib/decompress ZSTD_DECOMPRESS_FILES)
 set(ZSTD_SOURCES ${ZSTD_COMMON_FILES} ${ZSTD_COMPRESS_FILES} ${ZSTD_DECOMPRESS_FILES})
 
 add_library(zstd OBJECT ${ZSTD_SOURCES})
+target_compile_options(zstd PRIVATE -Wno-error)
 set_property(TARGET zstd PROPERTY POSITION_INDEPENDENT_CODE 1)
 
 set(PBSF_SOURCES

--- a/test/utils/test-functional.cc
+++ b/test/utils/test-functional.cc
@@ -22,6 +22,7 @@
 */
 
 #include <cassert>
+#include <cstdint>
 
 #include <bs3/utils/functional.hh>
 

--- a/test/utils/test-iter-util.cc
+++ b/test/utils/test-iter-util.cc
@@ -27,6 +27,12 @@
 #include <sstream>
 #include <bs3/utils/iter-util.hh>
 
+struct ncpas {
+  ncpas() = default;
+  ncpas(const ncpas&) = default;
+  ncpas& operator=(const ncpas&) = delete;
+};
+
 int main()
 {
 
@@ -141,7 +147,6 @@ int main()
 
       {
         // allow non-copy-assignable
-        struct ncpas { ncpas& operator=(const ncpas&) = delete; };
         int arr[] { 0 };
         auto it = make_mapping_iterator([](int) -> ncpas { return {}; }, arr);
         (void)*it;
@@ -230,7 +235,6 @@ int main()
 
       {
         // allow non-copy-assignable
-        struct ncpas { ncpas& operator=(const ncpas&) = delete; };
         int arr[] { 0 };
         auto it = make_skipping_mapping_iterator([](int) -> ncpas { return {}; }, arr);
         (void)*it;

--- a/test/utils/test-optional.cc
+++ b/test/utils/test-optional.cc
@@ -46,6 +46,7 @@ struct barfing_copyct {
   {
     assert("copy ctor must not be used" && false);
   }
+  barfing_copyct& operator=(const barfing_copyct&) = default;
 };
 
 struct tdible { int a; double b; };


### PR DESCRIPTION
... so that it compiles with CMake 4, GCC 15 / clang 20.

For CMake 4 I had to declare requiring cmake >= 3.5; let me know if support for 3.0 ~ 3.4 is still needed.